### PR TITLE
refactor to splat

### DIFF
--- a/AttractMode.ps1
+++ b/AttractMode.ps1
@@ -1,11 +1,11 @@
 param(
-    # The `Name` of the MicrosoftTerminal Profile
+    # The `Name` of the MicrosoftTerminal Profile.
     [Parameter(Mandatory = $true, Position = 0)]
     [string]
     [Alias('Profile')]
     $Name,
 
-    # The `Path` of the your awesome gifs that are clearly not copyrighted an totally appropriate to use in an OSS project
+    # The `Path` of the your awesome gifs that are clearly not copyrighted an totally appropriate to use in an OSS project.
     [Parameter(Mandatory = $true, Position = 1)]
     [string]
     [Alias('GifFolderPath')]
@@ -14,42 +14,36 @@ param(
     [Parameter(Mandatory = $false, Position = 2)]
     [int]
     [Alias('Secs')]
-    $seconds = 5
+    $Seconds = 5
 
 )
 $ErrorActionPreference = "Stop"
 
-#if(!(Get-Module -Name MSTerminalSettings -ListAvailable) )
+# This script depends on MSTerminalSettings. Install it if it's not available.
 if(-not (Get-Module -Name MSTerminalSettings -ListAvailable) )
 {
     Install-Module MSTerminalSettings
 }
 
-while ($true) {
-    #forloop over the path
-    Get-ChildItem $Path -Filter "*.gif" | ForEach-Object {
+# This hashtable will represent the parameters of Set-MSTerminalProfile... these 3 are constant so we'll set them here.
+$splat = @{
+    useAcrylic = $false
+    backgroundImageOpacity = 0.40
+    backgroundImageStretchMode = "fill"
+}
 
+while ($true) {
+    # Loop over the path
+    Get-ChildItem $Path -Filter "*.gif" | ForEach-Object {
+        # Grab the Profile right before we set it so we don't accidently stomp on other changes. 
         $terminalProfile = Get-MSTerminalProfile -Name $Name
 
-        $terminalProfile.useAcrylic = $false
+        # Change the background in the object.
+        $splat.backgroundImage = $_.FullName
 
-        if(!$terminalProfile.backgroundImage){
-            $terminalProfile | Add-Member -NotePropertyName backgroundImage -NotePropertyValue ""
-        }
-        $terminalProfile.backgroundImage = $_.FullName
+        # Splat the parameters into Set-MSTerminalProfile.
+        $terminalProfile | Set-MSTerminalProfile @splat
 
-        if(!$terminalProfile.backgroundImageOpacity){
-            $terminalProfile | Add-Member -NotePropertyName backgroundImageOpacity -NotePropertyValue 1
-        }
-        $terminalProfile.backgroundImageOpacity = 0.60
-
-        if(!$terminalProfile.backgroundImageStretchMode){
-            $terminalProfile | Add-Member -NotePropertyName backgroundImageStretchMode -NotePropertyValue ""
-        }
-        $terminalProfile.backgroundImageStretchMode = "stretchToFill"
-
-        $terminalProfile | Set-MSTerminalProfile 
-        
         Start-Sleep -Seconds $seconds
     }
 }

--- a/SetMoodGif.ps1
+++ b/SetMoodGif.ps1
@@ -11,31 +11,18 @@ param(
 )
 $ErrorActionPreference = "Stop"
 
-#if(!(Get-Module -Name MSTerminalSettings -ListAvailable) )
+# This script depends on MSTerminalSettings. Install it if it's not available.
 if(-not (Get-Module -Name MSTerminalSettings -ListAvailable) )
 {
     Install-Module MSTerminalSettings
 }
 
-$terminalProfile = Get-MSTerminalProfile -Name $Name
-
-$terminalProfile.useAcrylic = $false
-
-if(!$terminalProfile.backgroundImage){
-    $terminalProfile | Add-Member -NotePropertyName backgroundImage -NotePropertyValue ""
+# This hashtable will represent the parameters of Set-MSTerminalProfile.
+$splat = @{
+    useAcrylic = $false
+    backgroundImage = $Path
+    backgroundImageOpacity = 0.60
+    backgroundImageStretchMode = "fill"
 }
-$terminalProfile.backgroundImage = $path
 
-if(!$terminalProfile.backgroundImageOpacity){
-    $terminalProfile | Add-Member -NotePropertyName backgroundImageOpacity -NotePropertyValue 1
-}
-$terminalProfile.backgroundImageOpacity = 0.60
-
-if(!$terminalProfile.backgroundImageStretchMode){
-    $terminalProfile | Add-Member -NotePropertyName backgroundImageStretchMode -NotePropertyValue ""
-}
-$terminalProfile.backgroundImageStretchMode = "stretchToFill"
-
-$terminalProfile | Set-MSTerminalProfile 
-
-
+Get-MSTerminalProfile -Name $Name | Set-MSTerminalProfile @splat


### PR DESCRIPTION
[Splatting](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_splatting?view=powershell-6) is a very PowerShell-y concept. The idea is that you define the parameters for your command in a hashtable and then use the `@` sign instead of the `$` to "splat" them onto a command.

This change refactors to that so we don't have to use `Add-Member`.